### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Tuesdays and Thursdays, 2:30 PM - 4:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
# Add GitHub Skills Activity

## Overview
This PR adds the missing **GitHub Skills** extracurricular activity to the Mergington High School system.

## Changes Made
- ✅ Added "GitHub Skills" activity to the activities dictionary
- ✅ Set capacity to 25 students (high demand expected)
- ✅ Schedule: Tuesdays and Thursdays, 2:30 PM - 4:00 PM
- ✅ Description includes GitHub Certifications program info
- ✅ Ready for immediate student registration

## Resolves
- Closes #6 - 🚨 Missing Activity: GitHub Skills

## Context
Students have been waiting to register for this activity since the principal's announcement. The registration deadline is end of this week, making this time-sensitive.

## Testing
- [x] Activity appears in activities list
- [x] Students can register/unregister 
- [x] Capacity limits are enforced
- [x] Schedule information is displayed correctly

## Impact
- 🎓 Students can now register for GitHub Skills
- 📚 Supports GitHub Certifications program
- 🎯 Helps students with college applications
- ⏰ Meets the end-of-week registration deadline